### PR TITLE
add an sqlite db to enable the revoke api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ RUN git reset --hard ${VERSION}
 RUN dep ensure
 RUN make
 
+RUN go get bitbucket.org/liamstask/goose/cmd/goose
+
+RUN /go/bin/goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/sqlite create development
+RUN /go/bin/goose -path $GOPATH/src/github.com/cloudflare/cfssl/certdb/sqlite up
+
 FROM alpine:3.8
 
 LABEL maintainer="Joshua Rutherford <joshua.rutherfor@deciphernow.com>"
@@ -29,15 +34,19 @@ ENV CFSSL_CA_CERTIFICATE ""
 ENV CFSSL_CA_KEY ""
 
 COPY --from=0 /go/src/github.com/cloudflare/cfssl/bin /usr/local/bin
+COPY --from=0 /go/src/github.com/cloudflare/cfssl/certstore_development.db /var/lib/cfssl/certs.db
 COPY files/ /
 
-RUN chown -R 0:0 /etc/cfssl
-RUN chmod -R g=u /etc/cfssl
+RUN chown -R 0:0 /etc/cfssl && \
+  chmod -R g=u /etc/cfssl && \
+  chown -R 0:0 /var/lib/cfssl && \
+  chmod -R g=u /var/lib/cfssl
 
 EXPOSE 8888
 USER 1000
 VOLUME /etc/cfssl/tls
+VOLUME /var/lib/cfssl
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
-CMD ["/usr/local/bin/cfssl", "serve", "-config", "/etc/cfssl/config.json", "-address", "0.0.0.0", "-port", "8888", "-ca", "/etc/cfssl/tls/ca.crt", "-ca-key", "/etc/cfssl/tls/ca.key"] 
+CMD ["/usr/local/bin/cfssl", "serve", "-config", "/etc/cfssl/config.json", "-address", "0.0.0.0", "-port", "8888", "-ca", "/etc/cfssl/tls/ca.crt", "-ca-key", "/etc/cfssl/tls/ca.key", "-db-config", "/etc/cfssl/db-config.json"] 

--- a/files/etc/cfssl/db-config.json
+++ b/files/etc/cfssl/db-config.json
@@ -1,0 +1,4 @@
+{
+    "driver": "sqlite3",
+    "data_source": "/var/lib/cfss/certs.db"
+}


### PR DESCRIPTION
Currently, the docker-cfssl image does not allow the revoke api because there is no `db-config` option set.  This update adds the `db-config` option and a sqlite db for the option to work.  Below is the run log after the new image is built and you can see that the revoke api is enabled now

```
➜  docker-cfssl git:(db-config) ✗ docker run --rm deciphernow/cfssl:b94e044
2019/02/19 14:01:33 [INFO] Initializing signer
2019/02/19 14:01:33 [WARNING] couldn't initialize ocsp signer: open : no such file or directory
2019/02/19 14:01:33 [WARNING] endpoint 'ocspsign' is disabled: signer not initialized
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/revoke' is enabled
2019/02/19 14:01:33 [WARNING] endpoint '/' is disabled: could not locate box "static"
2019/02/19 14:01:33 [WARNING] endpoint 'authsign' is disabled: {"code":5200,"message":"Invalid or unknown policy"}
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/init_ca' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/scan' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/certinfo' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/health' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/sign' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/crl' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/newcert' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/scaninfo' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/gencrl' is enabled
2019/02/19 14:01:33 [INFO] setting up key / CSR generator
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/newkey' is enabled
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/info' is enabled
2019/02/19 14:01:33 [INFO] bundler API ready
2019/02/19 14:01:33 [INFO] endpoint '/api/v1/cfssl/bundle' is enabled
2019/02/19 14:01:33 [INFO] Handler set up complete.
2019/02/19 14:01:33 [INFO] Now listening on 0.0.0.0:8888
```