### PR TITLE
fix the missing l in the db-config

### DIFF
--- a/files/etc/cfssl/db-config.json
+++ b/files/etc/cfssl/db-config.json
@@ -1,4 +1,4 @@
 {
-    "driver": "sqlite3",
-    "data_source": "/var/lib/cfss/certs.db"
+  "driver": "sqlite3",
+  "data_source": "/var/lib/cfssl/certs.db"
 }


### PR DESCRIPTION
the db-config was missing an `l` in the `db-config.json` file.